### PR TITLE
add bin/langserver-jsts

### DIFF
--- a/bin/langserver-jsts
+++ b/bin/langserver-jsts
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require("../build/language-server-stdio.js");


### PR DESCRIPTION
We need to be able to point to a +x executable file that runs this stdio entrypoint, and the .js file is rewritten by tsc each time and loses its +x bit.